### PR TITLE
Adding pre-commit guardrail for hardcoded username, password, or authtoken

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,16 @@ repos:
         args: [--recursive, --format, json, --output, bandit-report.json]
         exclude: ^tests/
 
+  # Custom security check for config files
+  - repo: local
+    hooks:
+      - id: check-config-security
+        name: Check for hardcoded credentials in config files
+        entry: python pre-commit-scripts/check-config-security.py
+        language: system
+        files: ^config.*\.ya?ml$
+        pass_filenames: false
+
   # Documentation and markdown
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.45.0

--- a/config.yaml
+++ b/config.yaml
@@ -1,12 +1,13 @@
+# WARNING: Do not commit your sensitive credentials
 servers:
   local:
     default: true  # if server name is not provided in tool calls, this Spark History Server is used
     url: "http://localhost:18080"
-    # Optional authentication (can also use environment variables)
+    # Optional authentication (can also use environment variables).
     # auth:
-    #   username: "your_username"  # or use SHS_SPARK_USERNAME env var
-    #   password: "your_password"  # or use SHS_SPARK_PASSWORD env var
-    #   token: "your_token"       # or use SHS_SPARK_TOKEN env var
+    #   username: ${SHS_SPARK_USERNAME}
+    #   password: ${SHS_SPARK_PASSWORD}
+    #   token: ${SHS_SPARK_TOKEN}
 
   # Production server example
   # production:
@@ -23,8 +24,8 @@ servers:
   #   url: "https://staging-spark-history.company.com:18080"
   #   verify_ssl: true
   #   auth:
-      # username: "staging_user"
-      # token: "staging_token"
+      # username: ${SHS_SPARK_USERNAME}
+      # token: ${SHS_SPARK_TOKEN}
 
   # AWS Glue Spark History Server example
   # glue_ec2:

--- a/pre-commit-scripts/check-config-security.py
+++ b/pre-commit-scripts/check-config-security.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""
+Simple security check for config files to prevent hardcoded credentials.
+Detects non-commented username, password, and token fields with actual values.
+"""
+
+import logging
+import re
+import sys
+from pathlib import Path
+
+# Configure logging
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+
+def check_config_file(file_path):
+    """Check a YAML config file for hardcoded credentials using regex."""
+    errors = []
+
+    try:
+        with open(file_path, "r") as f:
+            lines = f.readlines()
+
+        for line_num, line in enumerate(lines, 1):
+            # Skip commented lines
+            stripped_line = line.strip()
+            if stripped_line.startswith("#") or not stripped_line:
+                continue
+
+            # Look for credential fields with values
+            # Pattern: field_name: "value" or field_name: value
+            credential_pattern = r'^\s*(username|password|token)\s*:\s*["\']?([^"\'\s#]+)["\']?\s*(?:#.*)?$'
+            match = re.match(credential_pattern, line, re.IGNORECASE)
+
+            if match:
+                field_name = match.group(1)
+                field_value = match.group(2)
+
+                # Skip environment variable references
+                if field_value.startswith("${") and field_value.endswith("}"):
+                    continue
+
+                # Skip obvious placeholders
+                placeholders = [
+                    "your_",
+                    "example_",
+                    "placeholder",
+                    "<",
+                    ">",
+                    "changeme",
+                    "replace",
+                    "todo",
+                    "fixme",
+                    "xxx",
+                    "yyy",
+                    "zzz",
+                ]
+                if any(
+                    placeholder in field_value.lower() for placeholder in placeholders
+                ):
+                    continue
+
+                # If we get here, it's likely a real credential
+                errors.append(
+                    f"Line {line_num}: Hardcoded {field_name} found: '{field_value}'"
+                )
+
+    except Exception as e:
+        logging.error(f"Error reading {file_path}: {e}")
+        errors.append(f"Error reading {file_path}: {e}")
+
+    return errors
+
+
+def main():
+    """Main function to check config files."""
+    config_files = [
+        "config.yaml",
+    ]
+
+    all_errors = []
+
+    for config_file in config_files:
+        if Path(config_file).exists():
+            errors = check_config_file(config_file)
+            if errors:
+                all_errors.extend([f"{config_file}: {error}" for error in errors])
+
+    if all_errors:
+        logging.error("🚨 SECURITY ISSUE: Hardcoded credentials detected!")
+        logging.error("❌ The following files contain hardcoded credentials:")
+        for error in all_errors:
+            logging.error(f"  • {error}")
+        logging.info("✅ Fix by using environment variables instead:")
+        logging.info('  username: "${SHS_SPARK_USERNAME}"')
+        logging.info('  password: "${SHS_SPARK_PASSWORD}"')
+        logging.info('  token: "${SHS_SPARK_TOKEN}"')
+        return 1
+
+    logging.info("✅ No hardcoded credentials found in config files")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

Currently, we are advising customers to add their username and password in the config.yaml file directly.

This is not best practice as it can encourage people to accidentally push their username and password directly to a feature branch.

Adding guardrail pre-commit check so that user cannot commit any hardcoded username, password or auth tokens. 

## 🎯 Type of Change
<!-- Mark with [x] -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

## 🧪 Testing
<!-- Describe how you tested your changes -->
- [x] ✅ All existing tests pass (`task test`)
- [x] 🔬 Tested with MCP Inspector
- [x] 📊 Tested with sample Spark data
- [x] 🚀 Tested with real Spark History Server (if applicable)


Tested the following scenarios:


Ignores placeholders
```
                placeholders = [
                    'your_', 'example_', 'placeholder', '<', '>', 'changeme', 
                    'replace', 'todo', 'fixme', 'xxx', 'yyy', 'zzz'
                ]
```


- Should succeed
```
servers:
  local:
    default: true  # if server name is not provided in tool calls, this Spark History Server is used
    url: "http://localhost:18080"
    #Optional authentication (can also use environment variables)
    auth:
      username: "your_username"  # or use SHS_SPARK_USERNAME env var
      password: "your_password"  # or use SHS_SPARK_PASSWORD env var
      token: "your_token"       # or use SHS_SPARK_TOKEN env var

```

- should fail
```
servers:
  local:
    default: true  # if server name is not provided in tool calls, this Spark History Server is used
    url: "http://localhost:18080"
    #Optional authentication (can also use environment variables)
    auth:
      username: "asdf"  # or use SHS_SPARK_USERNAME env var
      password: "your_password"  # or use SHS_SPARK_PASSWORD env var
      token: "your_token"       # or use SHS_SPARK_TOKEN env var

```

- should fail
```
servers:
  local:
    default: true  # if server name is not provided in tool calls, this Spark History Server is used
    url: "http://localhost:18080"
    #Optional authentication (can also use environment variables)
    auth:
      username: "your_username"  # or use SHS_SPARK_USERNAME env var
      password: "asdf"  # or use SHS_SPARK_PASSWORD env var
      token: "your_token"       # or use SHS_SPARK_TOKEN env var

```

- should fail
```
servers:
  local:
    default: true  # if server name is not provided in tool calls, this Spark History Server is used
    url: "http://localhost:18080"
    #Optional authentication (can also use environment variables)
    auth:
      username: "your_username"  # or use SHS_SPARK_USERNAME env var
      password: "your_password"  # or use SHS_SPARK_PASSWORD env var
      token: "asdf"       # or use SHS_SPARK_TOKEN env var

```

RESULTS
```
Check for hardcoded credentials in config files..........................Failed
- hook id: check-config-security
- exit code: 1

🚨 SECURITY ISSUE: Hardcoded credentials detected!
❌ The following files contain hardcoded credentials:

  • config.yaml: Line 7: Hardcoded username found: 'sdf'

✅ Fix by using environment variables instead:
  username: "${SHS_SPARK_USERNAME}"
  password: "${SHS_SPARK_PASSWORD}"
  token: "${SHS_SPARK_TOKEN}"

task: Failed to run task "pre-commit": exit status 1
```

## ✅ Checklist
-  [x] 🔍 Code follows project style guidelines
- [ ] 🧪 Added tests for new functionality
- [ ] 📖 Updated documentation (README, TESTING.md, etc.)
- [x] 🔧 Pre-commit hooks pass
- [ ] 📝 Added entry to CHANGELOG.md (if significant change)

## 📚 Related Issues
<!-- Link any related issues -->
Fixes #42 

## 🤔 Additional Context
<!-- Add any additional context, screenshots, or notes -->

---
**🎉 Thank you for contributing!** Your effort helps make Spark monitoring more intelligent.
