### PR TITLE
Support dot env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,10 @@
 # Spark History Server MCP Configuration
 
 # MCP Server Settings
-SHS_MCP_PORT # Port for MCP server (default: 18888)
-SHS_MCP_DEBUG # Enable debug mode (default: false)
-SHS_MCP_ADDRESS # Address for MCP server (default: localhost)
-SHS_MCP_TRANSPORT #MCP transport mode (default: streamable-http)
+SHS_MCP_PORT=18888 # Port for MCP server (default: 18888)
+SHS_MCP_DEBUG=true # Enable debug mode (default: false)
+SHS_MCP_ADDRESS=0.0.0.0 # Address for MCP server (default: localhost)
+SHS_MCP_TRANSPORT=treamable-http
 
 # Spark History Server Settings
 # SHS_SERVERS_*_URL - URL for a specific server

--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,15 @@
 # Spark History Server MCP Configuration
 
 # MCP Server Settings
-MCP_PORT=18888
-MCP_DEBUG=false
+SHS_MCP_PORT # Port for MCP server (default: 18888)
+SHS_MCP_DEBUG # Enable debug mode (default: false)
+SHS_MCP_ADDRESS # Address for MCP server (default: localhost)
+SHS_MCP_TRANSPORT #MCP transport mode (default: streamable-http)
 
-# Spark Authentication (Optional)
-# SPARK_USERNAME=your_spark_username
-# SPARK_PASSWORD=your_spark_password
-# SPARK_TOKEN=your_spark_token
-
-# Example for production:
-# SPARK_USERNAME=prod_user
-# SPARK_PASSWORD=secure_password_here
-# SPARK_TOKEN=jwt_token_here
+# Spark History Server Settings
+# SHS_SERVERS_*_URL - URL for a specific server
+# SHS_SERVERS_*_AUTH_USERNAME - Username for a specific server
+# SHS_SERVERS_*_AUTH_PASSWORD - Password for a specific server
+# SHS_SERVERS_*_AUTH_TOKEN - Token for a specific server
+# SHS_SERVERS_*_VERIFY_SSL - Whether to verify SSL for a specific server (true/false)
+# SHS_SERVERS_*_EMR_CLUSTER_ARN - EMR cluster ARN for a specific server

--- a/README.md
+++ b/README.md
@@ -262,13 +262,17 @@ servers:
 ```
 
 ### 🔐 Environment Variables
-```bash
-SHS_SPARK_USERNAME=your_username
-SHS_SPARK_PASSWORD=your_password
-SHS_SPARK_TOKEN=your_jwt_token
-SHS_MCP_PORT=18888
-SHS_MCP_DEBUG=false
-SHS_MCP_ADDRESS=0.0.0.0
+```
+SHS_MCP_PORT - Port for MCP server (default: 18888)
+SHS_MCP_DEBUG - Enable debug mode (default: false)
+SHS_MCP_ADDRESS - Address for MCP server (default: localhost)
+SHS_MCP_TRANSPORT - MCP transport mode (default: streamable-http)
+SHS_SERVERS_*_URL - URL for a specific server
+SHS_SERVERS_*_AUTH_USERNAME - Username for a specific server
+SHS_SERVERS_*_AUTH_PASSWORD - Password for a specific server
+SHS_SERVERS_*_AUTH_TOKEN - Token for a specific server
+SHS_SERVERS_*_VERIFY_SSL - Whether to verify SSL for a specific server (true/false)
+SHS_SERVERS_*_EMR_CLUSTER_ARN - EMR cluster ARN for a specific server
 ```
 
 ## 🤖 AI Agent Integration

--- a/config.yaml
+++ b/config.yaml
@@ -5,8 +5,8 @@ servers:
     url: "http://localhost:18080"
     # Optional authentication (can also use environment variables).
     # auth:
-    #   username: ${SHS_SPARK_USERNAME}
-    #   password: ${SHS_SPARK_PASSWORD}
+    #   username: ${SHS_SERVERS_LOCAL_AUTH_USERNAME}
+    #   password: ${SHS_SERVERS_LOCAL_AUTH_PASSWORD}
     #   token: ${SHS_SPARK_TOKEN}
 
   # Production server example
@@ -15,8 +15,8 @@ servers:
   #   verify_ssl: true
   #   auth:
       # Use environment variables for production
-      # username: ${SHS_SPARK_USERNAME}
-      # password: ${SHS_SPARK_PASSWORD}
+      # username: ${SHS_SERVERS_PRODUCTION_AUTH_USERNAME}
+      # password: ${SHS_SERVERS_PRODUCTION_AUTH_PASSWORD}
       # token: ${SHS_SPARK_TOKEN}
 
   # Staging server example
@@ -24,8 +24,8 @@ servers:
   #   url: "https://staging-spark-history.company.com:18080"
   #   verify_ssl: true
   #   auth:
-      # username: ${SHS_SPARK_USERNAME}
-      # token: ${SHS_SPARK_TOKEN}
+      # username: ${SHS_SERVERS_STAGING_AUTH_USERNAME}
+      # token: ${SHS_SERVERS_STAGING_AUTH_PASSWORD}
 
   # AWS Glue Spark History Server example
   # glue_ec2:
@@ -43,9 +43,15 @@ mcp:
   debug: true
   address: localhost
 
-# Environment Variables:
-# SHS_SPARK_USERNAME - Default username for authentication
-# SHS_SPARK_PASSWORD - Default password for authentication
-# SHS_SPARK_TOKEN - Default token for authentication
+
+# Available Environment Variables:
 # SHS_MCP_PORT - Port for MCP server (default: 18888)
 # SHS_MCP_DEBUG - Enable debug mode (default: false)
+# SHS_MCP_ADDRESS - Address for MCP server (default: localhost)
+# SHS_MCP_TRANSPORT - MCP transport mode (default: streamable-http)
+# SHS_SERVERS_*_URL - URL for a specific server
+# SHS_SERVERS_*_AUTH_USERNAME - Username for a specific server
+# SHS_SERVERS_*_AUTH_PASSWORD - Password for a specific server
+# SHS_SERVERS_*_AUTH_TOKEN - Token for a specific server
+# SHS_SERVERS_*_VERIFY_SSL - Whether to verify SSL for a specific server (true/false)
+# SHS_SERVERS_*_EMR_CLUSTER_ARN - EMR cluster ARN for a specific server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "requests~=2.32.4",
     "pydantic~=2.4",
     "boto3~=1.34",
+    "pydantic-settings>=2.9.1",
 ]
 
 # Development dependencies moved to [dependency-groups] section below

--- a/src/spark_history_mcp/core/app.py
+++ b/src/spark_history_mcp/core/app.py
@@ -65,12 +65,10 @@ async def app_lifespan(server: FastMCP) -> AsyncIterator[AppContext]:
     yield AppContext(clients=clients, default_client=default_client)
 
 
-def run():
-    config = Config.from_file("config.yaml")
-
-    mcp.settings.host = os.getenv("SHS_MCP_ADDRESS", config.mcp.address)
-    mcp.settings.port = int(os.getenv("SHS_MCP_PORT", config.mcp.port))
-    mcp.settings.debug = bool(os.getenv("SHS_MCP_DEBUG", config.mcp.debug))
+def run(config: Config):
+    mcp.settings.host = config.mcp.address
+    mcp.settings.port = int(config.mcp.port)
+    mcp.settings.debug = bool(config.mcp.debug)
     mcp.run(transport=os.getenv("SHS_MCP_TRANSPORT", config.mcp.transports[0]))
 
 

--- a/src/spark_history_mcp/core/main.py
+++ b/src/spark_history_mcp/core/main.py
@@ -1,8 +1,10 @@
 """Main entry point for Spark History Server MCP."""
 
+import json
 import logging
 import sys
 
+from spark_history_mcp.config.config import Config
 from spark_history_mcp.core import app
 
 # Configure logging
@@ -16,7 +18,11 @@ def main():
     """Main entry point."""
     try:
         logger.info("Starting Spark History Server MCP...")
-        app.run()
+        config = Config.from_file("config.yaml")
+        if config.mcp.debug:
+            logger.setLevel(logging.DEBUG)
+        logger.debug(json.dumps(json.loads(config.model_dump_json()), indent=4))
+        app.run(config)
     except Exception as e:
         logger.error(f"Failed to start MCP server: {e}")
         sys.exit(1)

--- a/tests/unit/config.py
+++ b/tests/unit/config.py
@@ -1,0 +1,182 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import yaml
+
+from spark_history_mcp.config.config import AuthConfig, Config, ServerConfig
+
+
+class TestConfig(unittest.TestCase):
+    """Test cases for the Config class."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        # Sample config data for testing
+        self.config_data = {
+            "servers": {
+                "test_server": {
+                    "url": "http://test-server:18080",
+                    "auth": {"username": "test_user", "password": "test_pass"},
+                    "default": True,
+                    "verify_ssl": True,
+                }
+            },
+            "mcp": {
+                "address": "test_host",
+                "port": 9999,
+                "transports": ["streamable-http", "sse"],
+                "debug": False,
+            },
+        }
+
+    def test_config_from_file(self):
+        """Test loading configuration from a file."""
+        # Create a temporary config file
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_file:
+            yaml.dump(self.config_data, temp_file)
+            temp_file_path = temp_file.name
+
+        try:
+            # Load config from the file
+            config = Config.from_file(temp_file_path)
+
+            # Verify the loaded configuration
+            self.assertEqual(config.mcp.address, "test_host")
+            self.assertEqual(config.mcp.port, 9999)
+            self.assertEqual(len(config.mcp.transports), 2)
+            self.assertIn("streamable-http", config.mcp.transports)
+            self.assertIn("sse", config.mcp.transports)
+            self.assertFalse(config.mcp.debug)
+
+            # Verify server config
+            self.assertIn("test_server", config.servers)
+            server = config.servers["test_server"]
+            self.assertEqual(server.url, "http://test-server:18080")
+            self.assertEqual(server.auth.username, "test_user")
+            self.assertEqual(server.auth.password, "test_pass")
+            self.assertTrue(server.default)
+            self.assertTrue(server.verify_ssl)
+        finally:
+            # Clean up the temporary file
+            os.unlink(temp_file_path)
+
+    def test_nonexistent_config_file(self):
+        """Test behavior when config file doesn't exist."""
+        with self.assertRaises(FileNotFoundError):
+            Config.from_file("nonexistent_file.yaml")
+
+    @patch.dict(
+        os.environ,
+        {
+            "SHS_MCP_ADDRESS": "env_host",
+            "SHS_MCP_PORT": "8888",
+            "SHS_MCP_DEBUG": "true",
+            "SHS_SERVERS_ENV_SERVER_URL": "http://env-server:18080",
+            "SHS_SERVERS_ENV_SERVER_AUTH_USERNAME": "env_user",
+            "SHS_SERVERS_ENV_SERVER_AUTH_PASSWORD": "env_pass",
+            "SHS_SERVERS_ENV_SERVER_DEFAULT": "true",
+        },
+    )
+    def test_config_from_env_vars(self):
+        """Test loading configuration from environment variables."""
+        # Create minimal config with empty servers dict to be populated from env
+        minimal_config = {"servers": {}}
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_file:
+            yaml.dump(minimal_config, temp_file)
+            temp_file_path = temp_file.name
+
+        try:
+            config = Config.from_file(temp_file_path)
+
+            # Verify MCP config from env vars
+            self.assertEqual(config.mcp.address, "env_host")
+            self.assertEqual(config.mcp.port, "8888")
+            self.assertTrue(config.mcp.debug)
+
+            # Verify server config from env vars
+            self.assertIn("env_server", config.servers)
+            server = config.servers["env_server"]
+            self.assertEqual(server.url, "http://env-server:18080")
+            self.assertEqual(server.auth.username, "env_user")
+            self.assertEqual(server.auth.password, "env_pass")
+            self.assertTrue(server.default)
+        finally:
+            os.unlink(temp_file_path)
+
+    @patch.dict(
+        os.environ,
+        {
+            "SHS_MCP_ADDRESS": "override_host",
+            "SHS_MCP_PORT": "7777",
+            "SHS_SERVERS_TEST_SERVER_URL": "http://override-server:18080",
+            "SHS_SERVERS_TEST_SERVER_AUTH_USERNAME": "override_user",
+        },
+    )
+    def test_env_vars_override_file_config(self):
+        """Test that environment variables take precedence over file configuration."""
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_file:
+            yaml.dump(self.config_data, temp_file)
+            temp_file_path = temp_file.name
+
+        try:
+            config = Config.from_file(temp_file_path)
+
+            # Verify that env vars override file config
+            self.assertEqual(config.mcp.address, "override_host")
+            self.assertEqual(config.mcp.port, "7777")
+
+            # Verify that server config is overridden
+            server = config.servers["test_server"]
+            self.assertEqual(server.url, "http://override-server:18080")
+            self.assertEqual(server.auth.username, "override_user")
+
+            # Password should still be from file as it wasn't overridden
+            self.assertEqual(server.auth.password, "test_pass")
+        finally:
+            os.unlink(temp_file_path)
+
+    def test_default_values(self):
+        """Test that default values are set correctly when not specified."""
+        minimal_config = {"servers": {"minimal": {"url": "http://minimal:18080"}}}
+
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_file:
+            yaml.dump(minimal_config, temp_file)
+            temp_file_path = temp_file.name
+
+        try:
+            config = Config.from_file(temp_file_path)
+
+            # Check MCP defaults
+            self.assertEqual(config.mcp.address, "localhost")
+            self.assertEqual(config.mcp.port, "18888")
+            self.assertFalse(config.mcp.debug)
+            self.assertEqual(config.mcp.transports, ["streamable-http"])
+
+            # Check server defaults
+            server = config.servers["minimal"]
+            self.assertEqual(server.url, "http://minimal:18080")
+            self.assertFalse(server.default)
+            self.assertTrue(server.verify_ssl)
+            self.assertIsNone(server.emr_cluster_arn)
+            self.assertIsNotNone(server.auth)
+            self.assertIsNone(server.auth.username)
+            self.assertIsNone(server.auth.password)
+            self.assertIsNone(server.auth.token)
+        finally:
+            os.unlink(temp_file_path)
+
+    def test_model_serialization(self):
+        """Test that models serialize correctly, especially with excluded fields."""
+        auth = AuthConfig(username="test_user", password="")
+        server = ServerConfig(url="http://test:18080", auth=auth)
+
+        # Test that auth is excluded from serialization
+        server_dict = server.model_dump()
+        self.assertIn("auth", server_dict)
+
+        # Test with explicit exclude
+        server_dict = server.model_dump(exclude={"auth"})
+        self.assertNotIn("auth", server_dict)

--- a/uv.lock
+++ b/uv.lock
@@ -335,6 +335,7 @@ dependencies = [
     { name = "boto3" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "pyyaml" },
     { name = "requests" },
 ]
@@ -355,6 +356,7 @@ requires-dist = [
     { name = "boto3", specifier = "~=1.34" },
     { name = "mcp", extras = ["cli"], specifier = "~=1.9" },
     { name = "pydantic", specifier = "~=2.4" },
+    { name = "pydantic-settings", specifier = ">=2.9.1" },
     { name = "pyyaml", specifier = "~=6.0" },
     { name = "requests", specifier = "~=2.32.4" },
 ]


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

This adds support for dot env files. 
Updated it to use the pydandic settings class to handle de-serialization from different sources. Priority order is set as:
1. env vars
2. dot env
3. config file



## 🎯 Type of Change
<!-- Mark with [x] -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

## 🧪 Testing
<!-- Describe how you tested your changes -->
- [x] ✅ All existing tests pass (`task test`)
- [x] 🔬 Tested with MCP Inspector
- [x] 📊 Tested with sample Spark data
- [] 🚀 Tested with real Spark History Server (if applicable)

### 🔬 Test Commands Run
```bash
task test
task test-e2e
```

## 🛠️ New Tools Added (if applicable)
<!-- For new MCP tools -->
- **Tool Name**: `new_tool_name`
- **Purpose**: What it does
- **Usage**: Example parameters

## 📸 Screenshots (if applicable)
<!-- For UI changes or new tools, include MCP Inspector screenshots -->

## ✅ Checklist
- [ ] 🔍 Code follows project style guidelines
- [ ] 🧪 Added tests for new functionality
- [ ] 📖 Updated documentation (README, TESTING.md, etc.)
- [ ] 🔧 Pre-commit hooks pass
- [ ] 📝 Added entry to CHANGELOG.md (if significant change)

## 📚 Related Issues
<!-- Link any related issues -->
Fixes #(issue number)
Related to #(issue number)

## 🤔 Additional Context
<!-- Add any additional context, screenshots, or notes -->

---
**🎉 Thank you for contributing!** Your effort helps make Spark monitoring more intelligent.
