### PR TITLE
add configurations for publishing to pypi

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,17 +2,16 @@ name: release
 
 on:
   push:
-    branches: [ main ]
-    tags: [ 'v*' ]
-  pull_request:
-    branches: [ main ]
+    tags: [ 'v[0-9]+.[0-9]+.[0-9]+' ]
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    environment: deploy
     permissions:
       contents: read
       packages: write
+      id-token: write # required. https://docs.pypi.org/trusted-publishers/using-a-publisher/
 
     steps:
       - name: Checkout code
@@ -46,3 +45,15 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc #6.4.3
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPi
+        run: uv publish --index pypi --trusted-publishing always

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,12 @@ ENV UV_CACHE_DIR=/app/.cache
 
 WORKDIR /app
 
+RUN apt update && apt install git -y
+
 # Just in case for future external caching mechanisms
 RUN --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=.git,target=.git \
     uv sync --frozen --no-install-project --no-dev --no-editable
 
 COPY . /app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-apache-spark-history-server"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Model Context Protocol (MCP) server for Apache Spark History Server with job comparison and analytics"
 readme = "README.md"
 authors = [
@@ -27,14 +27,23 @@ dependencies = [
     "boto3~=1.34",
 ]
 
-# Development dependencies moved to [dependency-groups] section below
-
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/spark_history_mcp"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "/src"
+]
+
+[tool.hatch.version] # Get version from tag
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+version_scheme = "no-guess-dev"
 
 [project.scripts]
 spark-mcp = "spark_history_mcp.core.main:main"
@@ -84,3 +93,10 @@ dev = [
     "pre-commit~=3.0",
     "pytest-asyncio~=1.0",
 ]
+
+
+[[tool.uv.index]]
+name = "pypi-test"
+url = "https://test.pypi.org/simple/"
+publish-url = "https://test.pypi.org/legacy/"
+explicit = true


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

This automates the release process to pypi through GitHub workflow.
- Gets the version number from git tag via hatch-vcs.
- Only files in the `src` dir are included.


Successful in my fork: https://github.com/nabuskey/mcp-apache-spark-history-server/actions/runs/16532971026

