### PR TITLE
add default config values

### DIFF
--- a/src/spark_history_mcp/config/config.py
+++ b/src/spark_history_mcp/config/config.py
@@ -43,8 +43,10 @@ class McpConfig(BaseSettings):
 class Config(BaseSettings):
     """Configuration for the Spark client."""
 
-    servers: Dict[str, ServerConfig]
-    mcp: Optional[McpConfig] = None
+    servers: Dict[str, ServerConfig] = {
+        "local": ServerConfig(url="http://localhost:18080", default=True),
+    }
+    mcp: Optional[McpConfig] = McpConfig(transports=["streamable-http"])
     model_config = SettingsConfigDict(
         env_prefix="SHS_",
         env_nested_delimiter="_",
@@ -56,7 +58,7 @@ class Config(BaseSettings):
     def from_file(cls, file_path: str) -> "Config":
         """Load configuration from a YAML file."""
         if not os.path.exists(file_path):
-            raise FileNotFoundError(f"Config file not found: {file_path}")
+            return Config()
 
         with open(file_path, "r") as f:
             config_data = yaml.safe_load(f)


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

This adds default values for the root config object. This allows you to run the MCP server without config file in the execution directory. For example: `uvx --from mcp-apache-spark-history-server  spark-mcp`

## 🎯 Type of Change
<!-- Mark with [x] -->
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

## 🧪 Testing
<!-- Describe how you tested your changes -->
- [ ] ✅ All existing tests pass (`task test`)
- [ ] 🔬 Tested with MCP Inspector
- [ ] 📊 Tested with sample Spark data
- [ ] 🚀 Tested with real Spark History Server (if applicable)

### 🔬 Test Commands Run
```bash
# Example:
# task test
# npx @modelcontextprotocol/inspector uv run -m spark_history_mcp.core.main
```

## 🛠️ New Tools Added (if applicable)
<!-- For new MCP tools -->
- **Tool Name**: `new_tool_name`
- **Purpose**: What it does
- **Usage**: Example parameters

## 📸 Screenshots (if applicable)
<!-- For UI changes or new tools, include MCP Inspector screenshots -->

## ✅ Checklist
- [ ] 🔍 Code follows project style guidelines
- [ ] 🧪 Added tests for new functionality
- [ ] 📖 Updated documentation (README, TESTING.md, etc.)
- [ ] 🔧 Pre-commit hooks pass
- [ ] 📝 Added entry to CHANGELOG.md (if significant change)

## 📚 Related Issues
<!-- Link any related issues -->
Fixes #(issue number)
Related to #(issue number)

## 🤔 Additional Context
<!-- Add any additional context, screenshots, or notes -->

---
**🎉 Thank you for contributing!** Your effort helps make Spark monitoring more intelligent.
