### PR TITLE
avoid long execution time

### DIFF
--- a/src/spark_history_mcp/api/spark_client.py
+++ b/src/spark_history_mcp/api/spark_client.py
@@ -305,10 +305,10 @@ class SparkRestClient:
         Args:
             app_id: The application ID
             status: Filter by stage status
-            details: Whether to include task details
+            details: Whether to include task details (WARNING: Setting this to True can significantly slow down the API call due to the large amount of task data returned)
             with_summaries: Whether to include summary metrics
             quantiles: Comma-separated list of quantiles to use for summary metrics
-            task_status: Filter by task status
+            task_status: Filter by task status (only takes effect when details=true)
 
         Returns:
             List of StageData objects
@@ -321,7 +321,8 @@ class SparkRestClient:
 
         if status:
             params["status"] = [s.value for s in status]
-        if task_status:
+        # taskStatus parameter only takes effect when details=true
+        if task_status and details:
             params["taskStatus"] = [s.value for s in task_status]
 
         data = self._get(f"applications/{app_id}/stages", params)


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description

Currently we call SHS stages endpoint with `details=true`. This significantly increases the response time from SHS even with caching enabled. As far as I can tell, there's no need for us to call it with details. 

This also addresses a bug where we were using the submission time instead of task launch time to calculate task completion time.

I've also update tools to use heapq for more efficient top-k handling.

## 🎯 Type of Change
<!-- Mark with [x] -->
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

## 🧪 Testing
<!-- Describe how you tested your changes -->
- [x] ✅ All existing tests pass (`task test`)
- [x] 🔬 Tested with MCP Inspector
- [x] 📊 Tested with sample Spark data
- [x] 🚀 Tested with real Spark History Server (if applicable)


