### PR TITLE
Parallelizing API calls in compare_job_performance, adding troubleshooting steps for timeouts on large applications

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,142 @@
+# Troubleshooting Guide
+
+## Tools on Large Spark Application Timing Out
+
+Certain tools may timeout based on the size of the Spark application. For large Spark applications that process Gigabytes and Terabytes of data, an increase in timeout and java heap size may need to be applied in order for the tool to have enough time and space to produce an output.
+
+**For example**:
+The `compare_job_performance` tool can be slow for large applications.
+
+>`Error calling MCP tool: MCP error -32001: Request timed out`
+
+Apply the following changes to resolve this:
+
+### 1. MCP Client Timeouts
+
+**Problem:**
+- MCP Client itself (Q CLI, Kiro, ETC) has its own timeout configuration that can be adjusted.
+
+**Solution:**
+Update the `timeout` value in your MCP client configuration (e.g., `mcp.json`):
+
+```json
+"spark-history-server": {
+  "command": "uv",
+  "args": [
+    "run",
+    "-m",
+    "spark_history_mcp.core.main",
+    "--frozen"
+  ],
+  "env": {
+    "SHS_MCP_TRANSPORT": "stdio"
+  },
+  "disabled": false,
+  "autoApprove": [],
+  "timeout": 300000 <--- Update here
+}
+```
+
+**Note:** Format depends on client of choice.
+
+### 2: MCP Server Timeouts
+
+**Symptoms:**
+- `HTTPConnectionPool(host='localhost', port=18080): Read timed out. (read timeout=30)`
+- Server-side timeout errors
+
+**Solution:**
+Set the server timeout environment variable:
+
+```json
+"spark-history-server": {
+  "command": "uv",
+  "args": [
+    "run",
+    "-m",
+    "spark_history_mcp.core.main",
+    "--frozen"
+  ],
+  "env": {
+    "SHS_MCP_TRANSPORT": "stdio",
+    "SHS_SERVERS_LOCAL_TIMEOUT": "500" <-- Set this value in seconds
+  },
+  "disabled": false,
+  "autoApprove": [],
+  "timeout": 300000
+}
+```
+
+**Note:** SHS_SERVERS_<Replace with server name in config.yaml>_TIMEOUT
+
+### 3: JVM Heap Exhaustion
+
+**Symptoms:**
+- `HTTP ERROR 500 org.sparkproject.guava.util.concurrent.ExecutionError: java.lang.OutOfMemoryError: Java heap space`
+- Browser shows 500 error when accessing Spark History Server URLs
+- Tool fails with memory-related errors
+
+**Root Cause:**
+Spark History Server parses entire Spark event logs (JSON or Snappy-compressed JSON) into memory. For large jobs (many tasks, long-running, heavy shuffle), the log can be hundreds of MBs to multiple GBs.
+
+**Example Error:**
+```
+HTTP ERROR 500 org.sparkproject.guava.util.concurrent.ExecutionError: java.lang.OutOfMemoryError: Java heap space
+URI:    /history/application_id1/jobs/
+STATUS: 500
+MESSAGE:    org.sparkproject.guava.util.concurrent.ExecutionError: java.lang.OutOfMemoryError: Java heap space
+SERVLET:    org.apache.spark.deploy.history.HistoryServer$$anon$1-5fc930f0
+CAUSED BY:  org.sparkproject.guava.util.concurrent.ExecutionError: java.lang.OutOfMemoryError: Java heap space
+CAUSED BY:  java.lang.OutOfMemoryError: Java heap space
+```
+
+**Solution 1: Enable Hybrid Store (Recommended)**
+Configure hybrid store in `spark-defaults.conf` to use disk-backed storage and avoid loading everything into memory:
+
+```properties
+# Enable hybrid store to prevent OOM by using disk + memory storage
+spark.history.store.hybridStore.enabled true
+
+# Maximum memory usage for in-memory cache (adjust based on available RAM)
+spark.history.store.hybridStore.maxMemoryUsage 1g
+
+# Disk backend for overflow storage (ROCKSDB recommended for compatibility)
+spark.history.store.hybridStore.diskBackend ROCKSDB
+
+# Serialization format for disk storage (KRYO is more efficient than Java)
+spark.history.store.hybridStore.serializer KRYO
+
+# Local directory for disk-backed storage (ensure path exists and is writable)
+spark.history.store.path /path/to/local/history-store
+
+# Maximum disk usage to prevent runaway storage growth
+spark.history.store.maxDiskUsage 50g
+```
+
+**Configuration Details:**
+- `hybridStore.enabled`: Enables disk + memory hybrid storage instead of memory-only
+- `maxMemoryUsage`: Keeps frequently accessed data in memory for performance
+- `diskBackend`: ROCKSDB is more stable than LEVELDB on macOS
+- `serializer`: KRYO reduces storage size compared to Java serialization
+- `store.path`: Must be a writable local directory (create with `mkdir -p`)
+- `maxDiskUsage`: Prevents disk space exhaustion from large applications
+
+**Solution 2: Increase JVM Heap Size**
+If hybrid store is not sufficient, increase the Spark daemon memory:
+
+```bash
+export SPARK_DAEMON_MEMORY=4g
+```
+
+Then restart your Spark History Server.
+
+#### Quick Diagnosis
+
+1. **Check browser first**: Navigate to `http://localhost:18080/history/application_<app_id>/jobs/`
+   - If you see HTTP 500 with "OutOfMemoryError" → Problem 3 (increase SPARK_DAEMON_MEMORY)
+   - If page loads normally → Problem 1 or 2 (increase timeouts)
+
+2. **Check error message**:
+   - `MCP error -32001: Request timed out` → Problem 1 (MCP client timeout)
+   - `Read timed out. (read timeout=30)` → Problem 2 (MCP server timeout)
+   - `OutOfMemoryError` or `Java heap space` → Problem 3 (JVM heap)

--- a/src/spark_history_mcp/utils/utils.py
+++ b/src/spark_history_mcp/utils/utils.py
@@ -1,0 +1,58 @@
+"""
+Simple timeout handling and parallel execution for MCP tools.
+"""
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Callable, Dict, List, Tuple
+
+import requests
+
+
+def parallel_execute(
+    api_calls: List[Tuple[str, Callable]], max_workers: int = 6, timeout: int = 180
+) -> Dict[str, Any]:
+    """
+    Execute multiple API calls in parallel with error handling.
+
+    Args:
+        api_calls: List of (name, function) tuples
+        max_workers: Maximum number of parallel workers
+        timeout: Total timeout for all operations
+
+    Returns:
+        Dictionary with results and errors
+    """
+    results = {}
+    errors = []
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        # Submit all tasks
+        future_to_name = {executor.submit(func): name for name, func in api_calls}
+
+        # Collect results as they complete
+        for future in as_completed(future_to_name, timeout=timeout):
+            name = future_to_name[future]
+            try:
+                result = future.result()
+                results[name] = result
+            except requests.exceptions.HTTPError as e:
+                if e.response.status_code == 500:
+                    # Try to extract the actual error from response text
+                    error_text = (
+                        e.response.text if hasattr(e.response, "text") else str(e)
+                    )
+                    if (
+                        "OutOfMemoryError" in error_text
+                        or "Java heap space" in error_text
+                    ):
+                        error_msg = f"{name} failed: Spark History Server out of memory (increase SPARK_DAEMON_MEMORY)"
+                else:
+                    error_msg = (
+                        f"{name} failed: HTTP {e.response.status_code} - {str(e)}"
+                    )
+                errors.append(error_msg)
+            except Exception as e:
+                error_msg = f"{name} failed: {str(e)}"
+                errors.append(error_msg)
+
+    return {"results": results, "errors": errors}


### PR DESCRIPTION
Signed-off-by: Andrew Kim <andredk@amazon.com>

# 🔄 Pull Request

## 📝 Description

Adding optimization and debugging steps for timeout scenarios when querying large spark applications. This PR will apply the optimization to compare_job_performance tool, the most complex tool we have.

1. Some of the default timeouts are too short
2. Large spark applications that process large amounts of data can easily overflow the JVM heap space for SHS. In this case adding mitigation instrucitons
3. Some of the tools are not scaled to work with large spark applications. Certain tools may timeout based on the size of the Spark application. For large Spark applications that process Gigabytes and Terabytes of data, an increase in timeout and java heap size may need to be applied in order for the tool to have enough time and space to produce an output.

Solution:
- Added TROUBLESHOOTING.md to instruct users on setting up their environment to mitigate the issue.
- Added parallelized API caller method with graceful degradation that can help improve performance and query the SHS faster with parallelized api calls rather than sequential calls.

## 🎯 Type of Change
<!-- Mark with [x] -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

## 🧪 Testing
<!-- Describe how you tested your changes -->
- [x] ✅ All existing tests pass (`task test`)
- [x] 🔬 Tested with MCP Inspector
- [x] 📊 Tested with sample Spark data
- [x] 🚀 Tested with real Spark History Server (if applicable)

### 🔬 Test Commands Run

can you compare job performance between application_a and application_b? 

```
Based on the performance comparison, here's why application_a took much longer than application_b:

Key Performance Differences
Scale Mismatch:

App a (slower): 493 total executors, processed 856GB of input data
App b (faster): 1,765 total executors, processed 20.7TB of input data
The Problem: App A was severely under-resourced for its workload. Despite processing similar amounts of data conceptually, it had only 28% of the executors that App B had.

Resource Allocation Issues
Executor Efficiency:

App a: 65,393 completed tasks across 493 executors = ~133 tasks per executor
App b: 791,434 completed tasks across 1,765 executors = ~448 tasks per executor
Duration Impact:

App a: Total executor duration of 2.48 billion ms with much less parallelism
App b: Total executor duration of 23.1 billion ms but distributed across 3.6x more executors
Root Cause Analysis
The main issue is resource allocation. App 0166 was running with insufficient parallelism:

Under-provisioned cluster: Only 493 executors vs 1,765 needed
Poor task distribution: Tasks were queued up waiting for available executors
Serialized execution: Work that could run in parallel was forced to run sequentially
Recommendations
To fix this performance issue:

Increase executor count to match the workload size (aim for 1,500+ executors)
Monitor cluster resource availability on different days
Set dynamic allocation parameters to scale based on workload
Check if cluster capacity was limited on the day App A ran
The data shows App A was essentially running the same job with 1/4 the resources, which explains the significantly longer runtime.
```

### REvision 2
using the history store hybrid approach to resolve jvm issue, i was able to get a result for compare_job_performance after 236.157s on Q CLI

```
> Based on the performance comparison between these two applications:

## Application Overview
• **App 0166**: awsdw_lakesmith-load_dim_aws_offering_pricing_-20250818999999 (Aug 18)
• **App 0131**: awsdw_lakesmith-load_dim_aws_offering_pricing_-20250817999999 (Aug 17)

## Key Performance Differences

### Resource Usage
• **App 0131** used 3.6x more executors (1,765 vs 493)
• **App 0131** processed 24x more data (20.7TB vs 856GB input)
• **App 0131** had 12x more completed tasks (791K vs 65K)

### Job Performance
• **App 0166** had slightly more jobs (67 vs 73)
• **App 0166** took longer per job on average (175s vs 137s)
• **App 0131** had higher total duration (9,966s vs 11,704s)

### Data Processing
• **App 0131** handled significantly more shuffle operations:
  • Shuffle read: 71.6TB vs 2.8TB
  • Shuffle write: 62.7TB vs 2.2TB

### Reliability
• **App 0131** had more failed tasks (112 vs 3), likely due to its much larger scale

## Summary
App 0131 (Aug 17) was a much larger-scale job processing ~25x more data with proportionally more resources.
App 0166 (Aug 18) was more efficient per job but processed significantly less data. The performance 
difference appears to be primarily due to data volume rather than efficiency issues.
```




## ✅ Checklist
- [x] 🔍 Code follows project style guidelines
- [ ] 🧪 Added tests for new functionality
- [x] 📖 Updated documentation (README, TESTING.md, etc.)
- [x] 🔧 Pre-commit hooks pass
- [] 📝 Added entry to CHANGELOG.md (if significant change)

---
**🎉 Thank you for contributing!** Your effort helps make Spark monitoring more intelligent.
