### PR TITLE
Add list applications tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,13 @@ mcp:
 
 > **Note**: These tools are subject to change as we scale and improve the performance of the MCP server.
 
-The MCP server provides **17 specialized tools** organized by analysis patterns. LLMs can intelligently select and combine these tools based on user queries:
+The MCP server provides **18 specialized tools** organized by analysis patterns. LLMs can intelligently select and combine these tools based on user queries:
 
 ### 📊 Application Information
 *Basic application metadata and overview*
 | 🔧 Tool | 📝 Description |
 |---------|----------------|
+| `list_applications` | 📋 Get a list of all applications available on the Spark History Server with optional filtering by status, date ranges, and limits |
 | `get_application` | 📊 Get detailed information about a specific Spark application including status, resource usage, duration, and attempt details |
 
 ### 🔗 Job Analysis
@@ -194,6 +195,7 @@ The MCP server provides **17 specialized tools** organized by analysis patterns.
 ### 🤖 How LLMs Use These Tools
 
 **Query Pattern Examples:**
+- *"Show me all applications between 12 AM and 1 AM on 2025-06-27"* → `list_applications`
 - *"Why is my job slow?"* → `get_job_bottlenecks` + `list_slowest_stages` + `get_executor_summary`
 - *"Compare today vs yesterday"* → `compare_job_performance` + `compare_job_environments`
 - *"What's wrong with stage 5?"* → `get_stage` + `get_stage_task_summary`

--- a/src/spark_history_mcp/tools/tools.py
+++ b/src/spark_history_mcp/tools/tools.py
@@ -51,6 +51,48 @@ def get_client_or_default(ctx, server_name: Optional[str] = None):
 
 
 @mcp.tool()
+def list_applications(
+    server: Optional[str] = None,
+    status: Optional[list[str]] = None,
+    min_date: Optional[str] = None,
+    max_date: Optional[str] = None,
+    min_end_date: Optional[str] = None,
+    max_end_date: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> list[ApplicationInfo]:
+    """
+    Get a list of applications from the Spark History Server.
+
+    Args:
+        server: Optional server name to use (uses default if not specified)
+        status: Optional list only applications in the chosen state: [completed|running]
+        min_date: Optional earliest start date/time to list
+        max_date: Optional latest start date/time to list
+        min_end_date: Optional earliest end date/time to list
+        max_end_date: Optional latest end date/time to list
+        limit: Optional maximum number of applications to return (limits the number of applications listed)
+    Date format:
+        - Accepted: YYYY-MM-DD["T"HH:mm:ss.SSS"GMT"]
+        - Time is optional. If present, it must include milliseconds and the literal GMT.
+        - Examples: 2015-02-10, 2015-02-03T16:42:40.000GMT
+        - Timezone: All values are interpreted as GMT.
+    Returns:
+        List of ApplicationInfo objects for all applications
+    """
+    ctx = mcp.get_context()
+    client = get_client_or_default(ctx, server)
+
+    return client.list_applications(
+        status=status,
+        min_date=min_date,
+        max_date=max_date,
+        min_end_date=min_end_date,
+        max_end_date=max_end_date,
+        limit=limit,
+    )
+
+
+@mcp.tool()
 def get_application(app_id: str, server: Optional[str] = None) -> ApplicationInfo:
     """
     Get detailed information about a specific Spark application.


### PR DESCRIPTION
# 🔄 Pull Request

## 📝 Description
We should create a tool to list all applications that are available on the server.
it was mentioned in feature request: 
https://github.com/DeepDiagnostix-AI/mcp-apache-spark-history-server/issues/66

## 🎯 Type of Change
<!-- Mark with [x] -->
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📖 Documentation update
- [ ] 🧪 Test improvement
- [ ] 🔧 Refactoring (no functional changes)

## 🧪 Testing
<!-- Describe how you tested your changes -->
- [ x] ✅ All existing tests pass (`task test`)
- [ ] 🔬 Tested with MCP Inspector
- [x ] 📊 Tested with sample Spark data
- [ x] 🚀 Tested with real Spark History Server (if applicable)

### 🔬 Test Commands Run
```bash
# Example:
# task test
# npx @modelcontextprotocol/inspector uv run -m spark_history_mcp.core.main
```

=========================================== 70 passed, 1 warning in 2.17s ===========================================
✅ Tests completed!

## 🛠️ New Tools Added (if applicable)
<!-- For new MCP tools -->
- **Tool Name**: `new_tool_name`
- **Purpose**: What it does
- **Usage**: Example parameters

## 📸 Screenshots (if applicable)
<!-- For UI changes or new tools, include MCP Inspector screenshots -->
🤖 You are chatting with claude-3.7-sonnet

> can you list all my spark applications?

> I'll list all your Spark applications using the MCP server for Apache Spark History Server.


🛠️  Using tool: list_applications from mcp server spark-history-server
 ⋮
 ● Running list_applications with the param:
 ⋮  {
 ⋮    "name": "list_applications",
 ⋮    "arguments": {}
 ⋮  }

Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:

> y


 ⋮
 ● Completed in 0.626s


> Here are all your Spark applications:

## 📊 Spark Applications (3 total)

| Application ID | Name | Duration | Start Time | Status |
|----------------|------|----------|------------|--------|
| spark-cc4d115f011443d787f03a71a476a745 | NewYorkTaxiData_2025_06_27_03_56_52 | 8.5 minutes | 2025-06-27 03:56:52 | ✅ Completed |
| spark-110be3a8424d4a2789cb88134418217b | NewYorkTaxiData_2025_06_27_00_24_44 | 5.1 minutes | 2025-06-27 00:24:44 | ✅ Completed |
| spark-bcec39f6201b42b9925124595baad260 | PythonPi | 7.4 seconds | 2025-06-26 00:06:51 | ✅ Completed |

All applications are running Spark version 3.5.3 and have completed successfully. The taxi data processing jobs took significantly longer than the simple
PythonPi calculation job.

Would you like me to analyze any specific application's performance or compare them?

---------------

> Show me all applications between 12 AM and 1 AM on 2025-06-27

> I'll show you all applications that started between 12 AM and 1 AM on 2025-06-27.


🛠️  Using tool: list_applications from mcp server spark-history-server
 ⋮
 ● Running list_applications with the param:
 ⋮  {
 ⋮    "name": "list_applications",
 ⋮    "arguments": {
 ⋮      "min_date": "2025-06-27T00:00:00.000GMT",
 ⋮      "max_date": "2025-06-27T01:00:00.000GMT"
 ⋮    }
 ⋮  }

Allow this action? Use 't' to trust (always allow) this tool for the session. [y/n/t]:

> y


 ⋮
 ● Completed in 0.76s


> ## 📊 Applications (12 AM - 1 AM, June 27, 2025)

There was 1 application that started during this time window:

| Application ID | Name | Start Time | End Time | Duration | Status |
|----------------|------|------------|----------|----------|--------|
| spark-110be3a8424d4a2789cb88134418217b | NewYorkTaxiData_2025_06_27_00_24_44 | 00:24:44 UTC | 00:29:48 UTC | 5.1 minutes | ✅ Completed |

Details:
• **Job Type:** New York Taxi Data processing
• **Spark Version:** 3.5.3
• **User:** spark
• **Execution:** Started at 12:24 AM and completed successfully in about 5 minutes

This appears to be a batch ETL job processing taxi data that ran during the early morning hours.

## ✅ Checklist
- [x ] 🔍 Code follows project style guidelines
- [x ] 🧪 Added tests for new functionality
- [ ] 📖 Updated documentation (README, TESTING.md, etc.)
- [ x] 🔧 Pre-commit hooks pass
- [ ] 📝 Added entry to CHANGELOG.md (if significant change)

## 📚 Related Issues
<!-- Link any related issues -->
Fixes #(issue number)
Related to #(issue number)

## 🤔 Additional Context
<!-- Add any additional context, screenshots, or notes -->

---
**🎉 Thank you for contributing!** Your effort helps make Spark monitoring more intelligent.
